### PR TITLE
Track whether the chip store is or is not using the built in chip.

### DIFF
--- a/web/src/pages/chip.tsx
+++ b/web/src/pages/chip.tsx
@@ -146,6 +146,7 @@ export const Chip = () => {
   const [useBuiltin, setUseBuiltin] = useState(false);
   const toggleUseBuiltin = async () => {
     if (useBuiltin) {
+      actions.useBuiltin(false);
       compile.current();
       setUseBuiltin(false);
     } else {


### PR DESCRIPTION
Correctly reset tests when toggling built-in chip.