### PR TITLE
Always load the new chip, then switch to the builtin if necessary.

### DIFF
--- a/components/src/stores/chip.store.ts
+++ b/components/src/stores/chip.store.ts
@@ -239,10 +239,9 @@ export function makeChipStore(
     ) {
       chipName = storage["/chip/chip"] = chip;
       dispatch.current({ action: "setChip", payload: chipName });
+      this.loadChip(project, chipName);
       if (usingBuiltin) {
         this.useBuiltin();
-      } else {
-        this.loadChip(project, chipName);
       }
     },
 


### PR DESCRIPTION
Closes #187.