### PR TITLE
Specify and enforce node and npm requirements

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# instruct npm to fail if the versions specified in the "engines"
+# section of package.json are not satisfied
+engine-strict=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,10 @@
         "eslint-plugin-react": "^7.31.11",
         "prettier": "^2.8.1",
         "typescript": "^4.9.4"
+      },
+      "engines": {
+        "node": ">=16",
+        "npm": ">=7"
       }
     },
     "cli": {

--- a/package.json
+++ b/package.json
@@ -49,5 +49,9 @@
     "runner",
     "simulator",
     "web"
-  ]
+  ],
+  "engines": {
+    "node": ">=16",
+    "npm": ">=7"
+  }
 }


### PR DESCRIPTION
Since this project uses workspaces it requires npm 7 or greater. This can take time to figure out if you don't know it. This change causes you to set npm to the appropriate version if you try to use an incorrect version within the project, e.g. when installing with `npm install`

I specified node>=16 simply because npm seemed to think that was the required version when specifying npm>=7.