### PR TITLE
Add different layouts for different screen scales

### DIFF
--- a/components/src/chips/screen.tsx
+++ b/components/src/chips/screen.tsx
@@ -1,6 +1,6 @@
 import { assertExists } from "@davidsouther/jiffies/lib/esm/assert.js";
 import { Memory } from "@nand2tetris/simulator/cpu/memory.js";
-import { useCallback, useRef } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useClockFrame, useClockReset } from "../clockface.js";
 
 const WHITE = "white";
@@ -50,12 +50,20 @@ function drawImage(ctx: CanvasRenderingContext2D, memory: ScreenMemory) {
 
 export const Screen = ({
   memory,
-  scale = 1,
+  showScaleControls = false,
+  onScale,
 }: {
   memory: ScreenMemory;
-  scale?: number;
+  showScaleControls?: boolean;
+  onScale?: (scale: number) => void;
 }) => {
   const canvas = useRef<HTMLCanvasElement>();
+  const [scale, setScale] = useState(1);
+
+  const onScaleCB = (scale: number) => {
+    onScale?.(scale);
+    setScale(scale);
+  };
 
   const draw = useCallback(() => {
     const ctx = canvas.current?.getContext("2d") ?? undefined;
@@ -82,32 +90,43 @@ export const Screen = ({
 
   return (
     <article className="panel">
-      <header>Screen</header>
-      <main style={{ backgroundColor: "var(--code-background-color)" }}>
-        <figure
-          style={{
-            width: `${512 * scale}px`,
-            height: `${256 * scale}px`,
-            boxSizing: "content-box",
-            marginInline: "auto",
-            margin: "auto",
-            borderTop: "2px solid gray",
-            borderLeft: "2px solid gray",
-            borderBottom: "2px solid lightgray",
-            borderRight: "2px solid lightgray",
-          }}
-        >
-          <canvas
-            ref={ctxRef}
-            width={512}
-            height={256}
+      <header>
+        <div>Screen</div>
+        {showScaleControls && (
+          <fieldset role="group">
+            <button onClick={() => onScaleCB(0)}>x0</button>
+            <button onClick={() => onScaleCB(1)}>x1</button>
+            <button onClick={() => onScaleCB(2)}>x2</button>
+          </fieldset>
+        )}
+      </header>
+      {scale > 0 && (
+        <main style={{ backgroundColor: "var(--code-background-color)" }}>
+          <figure
             style={{
-              transform: `translate(-50%, -50%) scale(${scale}) translate(50%, 50%)`,
-              imageRendering: "pixelated",
+              width: `${512 * scale}px`,
+              height: `${256 * scale}px`,
+              boxSizing: "content-box",
+              marginInline: "auto",
+              margin: "auto",
+              borderTop: "2px solid gray",
+              borderLeft: "2px solid gray",
+              borderBottom: "2px solid lightgray",
+              borderRight: "2px solid lightgray",
             }}
-          ></canvas>
-        </figure>
-      </main>
+          >
+            <canvas
+              ref={ctxRef}
+              width={512}
+              height={256}
+              style={{
+                transform: `translate(-50%, -50%) scale(${scale}) translate(50%, 50%)`,
+                imageRendering: "pixelated",
+              }}
+            ></canvas>
+          </figure>
+        </main>
+      )}
     </article>
   );
 };

--- a/components/src/runbar.tsx
+++ b/components/src/runbar.tsx
@@ -44,42 +44,46 @@ export const Runbar = (props: {
   };
 
   return (
-    <fieldset role="group">
-      {props.prefix}
-      <button
-        className="flex-0"
-        disabled={props.disabled}
-        onClick={() => runner.actions.frame()}
-        data-tooltip={props.overrideTooltips?.step ?? `Step`}
-        data-placement="bottom"
-      >
-        {/* <Icon name="play_arrow" /> */}
-        ➡️
-      </button>
-      <button
-        className="flex-0"
-        disabled={props.disabled}
-        onClick={() =>
-          runner.state.running ? runner.actions.stop() : runner.actions.start()
-        }
-        data-tooltip={
-          runner.state.running
-            ? props.overrideTooltips?.pause ?? `Pause`
-            : props.overrideTooltips?.run ?? `Run`
-        }
-        data-placement="bottom"
-      >
-        {/* <Icon name={runner.state.running ? "pause" : "fast_forward"} /> */}
-        {runner.state.running ? "⏸" : "️⏩"}
-      </button>
-      <button
-        className="flex-0"
-        onClick={() => runner.actions.reset()}
-        data-tooltip={props.overrideTooltips?.reset ?? `Reset`}
-        data-placement="bottom"
-      >
-        {/* <Icon name="fast_rewind" /> */}⏮
-      </button>
+    <div style={{ display: "flex", flexWrap: "wrap" }}>
+      <fieldset role="group">
+        {props.prefix}
+        <button
+          className="flex-0"
+          disabled={props.disabled}
+          onClick={() => runner.actions.frame()}
+          data-tooltip={props.overrideTooltips?.step ?? `Step`}
+          data-placement="bottom"
+        >
+          {/* <Icon name="play_arrow" /> */}
+          ➡️
+        </button>
+        <button
+          className="flex-0"
+          disabled={props.disabled}
+          onClick={() =>
+            runner.state.running
+              ? runner.actions.stop()
+              : runner.actions.start()
+          }
+          data-tooltip={
+            runner.state.running
+              ? props.overrideTooltips?.pause ?? `Pause`
+              : props.overrideTooltips?.run ?? `Run`
+          }
+          data-placement="bottom"
+        >
+          {/* <Icon name={runner.state.running ? "pause" : "fast_forward"} /> */}
+          {runner.state.running ? "⏸" : "️⏩"}
+        </button>
+        <button
+          className="flex-0"
+          onClick={() => runner.actions.reset()}
+          data-tooltip={props.overrideTooltips?.reset ?? `Reset`}
+          data-placement="bottom"
+        >
+          {/* <Icon name="fast_rewind" /> */}⏮
+        </button>
+      </fieldset>
       <div
         style={{
           display: "flex",
@@ -105,6 +109,6 @@ export const Runbar = (props: {
         <span style={{ padding: "0.2rem" }}>Fast</span>
       </div>
       {props.children}
-    </fieldset>
+    </div>
   );
 };

--- a/components/src/runbar.tsx
+++ b/components/src/runbar.tsx
@@ -44,7 +44,7 @@ export const Runbar = (props: {
   };
 
   return (
-    <div style={{ display: "flex", flexWrap: "wrap" }}>
+    <div className="flex row wrap">
       <fieldset role="group">
         {props.prefix}
         <button

--- a/web/src/pages/cpu.scss
+++ b/web/src/pages/cpu.scss
@@ -1,22 +1,34 @@
 @use "./page.scss";
 
 .CpuPage {
-  grid-template-areas: "ROM RAM" "IO IO" "test test";
-  grid-template-columns: 1fr 1fr !important;
-  grid-template-rows: 1fr 1fr 1fr !important;
+  &.normal {
+    grid-template-areas: "ROM RAM" "IO IO" "test test";
+    grid-template-columns: 1fr 1fr !important;
+    grid-template-rows: 1fr 1fr 1fr !important;
 
-  @media screen and (min-width: 1024px) {
-    grid-template-areas: "ROM RAM IO" "test test test";
-    grid-template-columns: 1fr 1fr var(--screen-size) !important;
-    grid-template-rows: 1fr 1fr !important;
+    @media screen and (min-width: 1024px) {
+      grid-template-areas: "ROM RAM IO" "test test test";
+      grid-template-columns: 1fr 1fr var(--screen-size) !important;
+      grid-template-rows: 1fr 1fr !important;
+    }
+
+    @media screen and (min-width: 1500px) {
+      grid-template-areas: "ROM RAM IO test";
+      grid-template-columns: 350px 350px var(--screen-size) auto !important;
+      grid-template-rows: 1fr !important;
+    }
   }
 
-  @media screen and (min-width: 1500px) {
-    grid-template-areas: "ROM RAM IO test";
-    grid-template-columns: 350px 350px var(--screen-size) auto !important;
-    grid-template-rows: 1fr !important;
-    // "IO IO test"
-    // "ROM RAM test";
+  &.large-screen {
+    grid-template-columns: 1fr 1fr calc(var(--screen-size) * 2);
+    grid-template-rows: 2fr 1fr;
+    grid-template-areas: "ROM RAM IO" "test test IO";
+
+    @media screen and (min-width: 2200px) {
+      grid-template-columns: 350px 350px calc(var(--screen-size) * 2) 1fr;
+      grid-template-rows: 1fr;
+      grid-template-areas: "ROM RAM IO test";
+    }
   }
 
   .memory.ROM {

--- a/web/src/pages/cpu.scss
+++ b/web/src/pages/cpu.scss
@@ -20,9 +20,9 @@
   }
 
   &.large-screen {
-    grid-template-columns: 1fr 1fr calc(var(--screen-size) * 2);
-    grid-template-rows: 2fr 1fr;
-    grid-template-areas: "ROM RAM IO" "test test IO";
+    grid-template-columns: 350px calc(var(--screen-size) * 2) 1fr;
+    grid-template-rows: 1fr 1fr;
+    grid-template-areas: "ROM IO test" "RAM IO test";
 
     @media screen and (min-width: 2200px) {
       grid-template-columns: 350px 350px calc(var(--screen-size) * 2) 1fr;

--- a/web/src/pages/cpu.tsx
+++ b/web/src/pages/cpu.tsx
@@ -117,8 +117,15 @@ export const CPU = () => {
     dispatch.current({ action: "update" });
   };
 
+  const [scale, setScale] = useState(1);
+  const onScale = (scale: number) => {
+    setScale(scale);
+  };
+
   return (
-    <div className="Page CpuPage grid">
+    <div
+      className={`Page CpuPage grid ${scale == 2 ? "large-screen" : "normal"}`}
+    >
       <MemoryComponent
         name="ROM"
         displayEnabled={displayEnabled}
@@ -147,7 +154,12 @@ export const CPU = () => {
           </>
         }
       >
-        <Screen key={screenRenderKey} memory={state.sim.Screen}></Screen>
+        <Screen
+          key={screenRenderKey}
+          memory={state.sim.Screen}
+          showScaleControls={true}
+          onScale={onScale}
+        ></Screen>
         <Keyboard update={onKeyChange} keyboard={state.sim.Keyboard} />
         <label>
           <input

--- a/web/src/pages/vm.scss
+++ b/web/src/pages/vm.scss
@@ -2,7 +2,7 @@
 
 .VmPage {
   grid-template-columns:
-    1fr calc(var(--screen-size) * 0.7) calc(var(--screen-size) * 0.7)
+    1fr calc(var(--screen-size) * 0.5) calc(var(--screen-size) * 0.5)
     1fr !important;
   grid-template-rows: auto 1fr 4fr !important;
   grid-template-areas:

--- a/web/src/pages/vm.scss
+++ b/web/src/pages/vm.scss
@@ -1,14 +1,37 @@
 @use "./page.scss";
 
 .VmPage {
-  grid-template-columns:
-    1fr calc(var(--screen-size) * 0.5) calc(var(--screen-size) * 0.5)
-    1fr !important;
-  grid-template-rows: auto 1fr 4fr !important;
-  grid-template-areas:
-    "program display display test"
-    "program stack RAM test"
-    "vm stack RAM test";
+  &.normal {
+    grid-template-columns:
+      1fr calc(var(--screen-size) * 0.5) calc(var(--screen-size) * 0.5)
+      1fr !important;
+    grid-template-rows: auto 1fr 4fr !important;
+    grid-template-areas:
+      "program display display test"
+      "program stack RAM test"
+      "vm stack RAM test";
+  }
+
+  &.no-screen {
+    grid-template-columns:
+      1fr calc(var(--screen-size) * 0.5) calc(var(--screen-size) * 0.5)
+      1fr !important;
+    grid-template-rows: auto 1fr 1fr !important;
+    grid-template-areas:
+      "program display display test"
+      "program stack RAM test"
+      "vm stack RAM test";
+  }
+
+  &.large-screen {
+    grid-template-columns:
+      1fr var(--screen-size) var(--screen-size)
+      1fr !important;
+    grid-template-rows: auto 1fr !important;
+    grid-template-areas:
+      "program display display test"
+      "vm stack RAM test";
+  }
 
   .program {
     grid-area: program;

--- a/web/src/pages/vm.tsx
+++ b/web/src/pages/vm.tsx
@@ -256,7 +256,7 @@ const VM = () => {
         )}
       </Panel>
       <Panel className="display" style={{ gridArea: "display" }}>
-        <Screen memory={state.vm.Screen} scale={1.4} />
+        <Screen memory={state.vm.Screen} />
         <Keyboard keyboard={state.vm.Keyboard} />
       </Panel>
       <Memory

--- a/web/src/pages/vm.tsx
+++ b/web/src/pages/vm.tsx
@@ -172,8 +172,17 @@ const VM = () => {
 
   const stackRef = useRef<Rerenderable>();
 
+  const [scale, setScale] = useState(1);
+  const onScale = (scale: number) => {
+    setScale(scale);
+  };
+
   return (
-    <div className="Page VmPage grid">
+    <div
+      className={`Page VmPage grid ${
+        scale == 0 ? "no-screen" : scale == 2 ? "large-screen" : "normal"
+      }`}
+    >
       <Panel
         className="program"
         header={
@@ -256,7 +265,11 @@ const VM = () => {
         )}
       </Panel>
       <Panel className="display" style={{ gridArea: "display" }}>
-        <Screen memory={state.vm.Screen} />
+        <Screen
+          memory={state.vm.Screen}
+          showScaleControls={true}
+          onScale={onScale}
+        />
         <Keyboard keyboard={state.vm.Keyboard} />
       </Panel>
       <Memory

--- a/web/src/pico/flex.scss
+++ b/web/src/pico/flex.scss
@@ -37,6 +37,10 @@
   &.align-end {
     align-items: end;
   }
+
+  &.wrap {
+    flex-wrap: wrap;
+  }
 }
 
 .flex-0 {


### PR DESCRIPTION
Screenshots:

**CPU Emulator**
x0 screen:
![Screenshot from 2024-03-21 12-38-41](https://github.com/nand2tetris/web-ide/assets/67196883/2dfa7dab-a74c-4aae-8af2-67470ce5c14e)

x1 screen:
![Screenshot from 2024-03-21 12-39-26](https://github.com/nand2tetris/web-ide/assets/67196883/6eab2b6e-0e58-4ac7-8cf2-e0da5c60b7df)

x2 screen:
![Screenshot from 2024-03-21 15-51-57](https://github.com/nand2tetris/web-ide/assets/67196883/95a37e03-fe9d-4cc3-979a-7de14f68a102)

**VM Emulator**
x0 screen:
![Screenshot from 2024-03-21 12-40-38](https://github.com/nand2tetris/web-ide/assets/67196883/2977c32f-f77d-42ee-8af8-e89b05ee95dc)

x1 screen:
![Screenshot from 2024-03-21 12-40-45](https://github.com/nand2tetris/web-ide/assets/67196883/d30eec87-8aab-4c32-a217-f76b62cf4a69)

x2 screen:
![Screenshot from 2024-03-21 12-40-58](https://github.com/nand2tetris/web-ide/assets/67196883/d34a7fd6-2a4d-46a4-9ca9-19cd4ce2ba9d)

