### PR TITLE
Fix asm parsing bugs

### DIFF
--- a/simulator/src/languages/asm.test.ts
+++ b/simulator/src/languages/asm.test.ts
@@ -10,7 +10,7 @@ describe("asm language", () => {
   });
 
   it("parses an A instruction to a label", () => {
-    const match = grammar.match("@R0", "AInstruction");
+    const match = grammar.match("@R0", "aInstruction");
     expect(match).toHaveSucceeded();
     expect(asmSemantics(match).instruction).toEqual({
       type: "A",
@@ -21,7 +21,7 @@ describe("asm language", () => {
   });
 
   it("parses an A instruction to a value", () => {
-    const match = grammar.match("@5", "AInstruction");
+    const match = grammar.match("@5", "aInstruction");
     expect(match).toHaveSucceeded();
     expect(asmSemantics(match).instruction).toEqual({
       type: "A",
@@ -32,7 +32,7 @@ describe("asm language", () => {
   });
 
   it("parses a C instruction", () => {
-    const match = grammar.match("-1", "CInstruction");
+    const match = grammar.match("-1", "cInstruction");
     expect(match).toHaveSucceeded();
     expect(asmSemantics(match).instruction).toEqual({
       type: "C",
@@ -43,7 +43,7 @@ describe("asm language", () => {
   });
 
   it("parses a C instruction with assignment", () => {
-    const match = grammar.match("D=M", "CInstruction");
+    const match = grammar.match("D=M", "cInstruction");
     expect(match).toHaveSucceeded();
     expect(asmSemantics(match).instruction).toEqual({
       type: "C",
@@ -55,7 +55,7 @@ describe("asm language", () => {
   });
 
   it("parses a C instruction with operation", () => {
-    const match = grammar.match("M=M+1", "CInstruction");
+    const match = grammar.match("M=M+1", "cInstruction");
     expect(match).toHaveSucceeded();
     expect(asmSemantics(match).instruction).toEqual({
       type: "C",
@@ -67,7 +67,7 @@ describe("asm language", () => {
   });
 
   it("parses a C instruction with jump", () => {
-    const match = grammar.match("D;JEQ", "CInstruction");
+    const match = grammar.match("D;JEQ", "cInstruction");
     expect(match).toHaveSucceeded();
     expect(asmSemantics(match).instruction).toEqual({
       type: "C",
@@ -79,7 +79,7 @@ describe("asm language", () => {
   });
 
   it("parses a C instruction with assignment and jump", () => {
-    const match = grammar.match("A=D;JEQ", "CInstruction");
+    const match = grammar.match("A=D;JEQ", "cInstruction");
     expect(match).toHaveSucceeded();
     expect(asmSemantics(match).instruction).toEqual({
       type: "C",

--- a/simulator/src/languages/asm.ts
+++ b/simulator/src/languages/asm.ts
@@ -76,7 +76,7 @@ asmSemantics.addAttribute<Asm>("root", {
 });
 
 asmSemantics.addAttribute<Asm>("asm", {
-  ASM(_, asm, last) {
+  ASM(asm, last) {
     const instructions =
       asm.children.map(
         (node) => node.intermediateInstruction as AsmInstruction
@@ -90,7 +90,7 @@ asmSemantics.addAttribute<Asm>("asm", {
 });
 
 asmSemantics.addAttribute<AsmInstruction>("intermediateInstruction", {
-  IntermediateInstruction(inst, _n) {
+  intermediateInstruction(inst, _n) {
     return inst.instruction;
   },
 });

--- a/simulator/src/languages/asm.ts
+++ b/simulator/src/languages/asm.ts
@@ -76,27 +76,37 @@ asmSemantics.addAttribute<Asm>("root", {
 });
 
 asmSemantics.addAttribute<Asm>("asm", {
-  Root(asm) {
+  ASM(asm, last) {
+    const instructions =
+      asm.children.map(
+        (node) => node.intermediateInstruction as AsmInstruction
+      ) ?? [];
     return {
-      instructions: asm
-        .child(0)
-        .children.map(({ instruction }) => instruction as AsmInstruction),
+      instructions: last.child(0)
+        ? [...instructions, last.child(0).instruction]
+        : instructions,
     };
   },
 });
 
+asmSemantics.addAttribute<AsmInstruction>("intermediateInstruction", {
+  IntermediateInstruction(inst, _n) {
+    return inst.instruction;
+  },
+});
+
 asmSemantics.addAttribute<AsmInstruction>("instruction", {
-  AInstruction(_at, name, _b): AsmAInstruction {
+  aInstruction(_at, name): AsmAInstruction {
     return A(name.value, span(this.source));
   },
-  CInstruction(assignN, opN, jmpN, _b): AsmCInstruction {
+  cInstruction(assignN, opN, jmpN): AsmCInstruction {
     const assign = (assignN.child(0)?.child(0)?.sourceString ??
       "") as ASSIGN_ASM;
     const op = opN.sourceString as COMMANDS_ASM;
     const jmp = (jmpN.child(0)?.child(1)?.sourceString ?? "") as JUMP_ASM;
     return C(assign, op, jmp, span(this.source));
   },
-  Label(_o, { name }, _c, _a): AsmLabelInstruction {
+  label(_o, { name }, _c): AsmLabelInstruction {
     return L(name, span(this.source));
   },
 });

--- a/simulator/src/languages/asm.ts
+++ b/simulator/src/languages/asm.ts
@@ -76,7 +76,7 @@ asmSemantics.addAttribute<Asm>("root", {
 });
 
 asmSemantics.addAttribute<Asm>("asm", {
-  ASM(asm, last) {
+  ASM(_, asm, last) {
     const instructions =
       asm.children.map(
         (node) => node.intermediateInstruction as AsmInstruction

--- a/simulator/src/languages/asm.ts
+++ b/simulator/src/languages/asm.ts
@@ -86,17 +86,17 @@ asmSemantics.addAttribute<Asm>("asm", {
 });
 
 asmSemantics.addAttribute<AsmInstruction>("instruction", {
-  AInstruction(_at, name): AsmAInstruction {
+  AInstruction(_at, name, _b): AsmAInstruction {
     return A(name.value, span(this.source));
   },
-  CInstruction(assignN, opN, jmpN): AsmCInstruction {
+  CInstruction(assignN, opN, jmpN, _b): AsmCInstruction {
     const assign = (assignN.child(0)?.child(0)?.sourceString ??
       "") as ASSIGN_ASM;
     const op = opN.sourceString as COMMANDS_ASM;
     const jmp = (jmpN.child(0)?.child(1)?.sourceString ?? "") as JUMP_ASM;
     return C(assign, op, jmp, span(this.source));
   },
-  Label(_o, { name }, _c): AsmLabelInstruction {
+  Label(_o, { name }, _c, _a): AsmLabelInstruction {
     return L(name, span(this.source));
   },
 });

--- a/simulator/src/languages/grammars/asm.ohm
+++ b/simulator/src/languages/grammars/asm.ohm
@@ -1,6 +1,6 @@
 ASM <: Base {
   Root := ASM
-  ASM = IntermediateInstruction* instruction ?
+  ASM = newline* IntermediateInstruction* instruction?
   
   instruction = label|aInstruction|cInstruction
   IntermediateInstruction = instruction newline+

--- a/simulator/src/languages/grammars/asm.ohm
+++ b/simulator/src/languages/grammars/asm.ohm
@@ -1,12 +1,15 @@
 ASM <: Base {
   Root := ASM
-  ASM = Instruction*
+  ASM = IntermediateInstruction* instruction ?
   
-  Instruction = Label|AInstruction|CInstruction
-  
-  Label = OpenParen identifier closeParen newline
-  AInstruction = at (identifier | decNumber) newline
-  CInstruction = assign? op jmp? newline
+  instruction = label|aInstruction|cInstruction
+  IntermediateInstruction = instruction newline+
+
+  space := ~"\\n" "\\x00".."\\x20"
+
+  label = openParen identifier closeParen
+  aInstruction = at (identifier | decNumber)
+  cInstruction = assign? op jmp?
   
   assign = (
       "AMD"

--- a/simulator/src/languages/grammars/asm.ohm
+++ b/simulator/src/languages/grammars/asm.ohm
@@ -1,11 +1,9 @@
 ASM <: Base {
   Root := ASM
-  ASM = newline* IntermediateInstruction* instruction?
+  ASM = intermediateInstruction* instruction?
   
   instruction = label|aInstruction|cInstruction
-  IntermediateInstruction = instruction newline+
-
-  space := ~"\\n" "\\x00".."\\x20"
+  intermediateInstruction = instruction space+
 
   label = openParen identifier closeParen
   aInstruction = at (identifier | decNumber)

--- a/simulator/src/languages/grammars/asm.ohm
+++ b/simulator/src/languages/grammars/asm.ohm
@@ -4,9 +4,9 @@ ASM <: Base {
   
   Instruction = Label|AInstruction|CInstruction
   
-  Label = OpenParen identifier closeParen
-  AInstruction = at (identifier | decNumber)
-  CInstruction = assign? op jmp?
+  Label = OpenParen identifier closeParen newline
+  AInstruction = at (identifier | decNumber) newline
+  CInstruction = assign? op jmp? newline
   
   assign = (
       "AMD"

--- a/simulator/src/languages/grammars/asm.ohm.js
+++ b/simulator/src/languages/grammars/asm.ohm.js
@@ -5,9 +5,9 @@ ASM <: Base {
   
   Instruction = Label|AInstruction|CInstruction
   
-  Label = OpenParen identifier closeParen
-  AInstruction = at (identifier | decNumber)
-  CInstruction = assign? op jmp?
+  Label = OpenParen identifier closeParen newline
+  AInstruction = at (identifier | decNumber) newline
+  CInstruction = assign? op jmp? newline
   
   assign = (
       "AMD"

--- a/simulator/src/languages/grammars/asm.ohm.js
+++ b/simulator/src/languages/grammars/asm.ohm.js
@@ -1,13 +1,16 @@
 const asm = `
 ASM <: Base {
   Root := ASM
-  ASM = Instruction*
+  ASM = IntermediateInstruction* instruction?
   
-  Instruction = Label|AInstruction|CInstruction
-  
-  Label = OpenParen identifier closeParen newline
-  AInstruction = at (identifier | decNumber) newline
-  CInstruction = assign? op jmp? newline
+  instruction = label|aInstruction|cInstruction
+  IntermediateInstruction = instruction newline+
+
+  space := ~"\\n" "\\x00".."\\x20"
+
+  label = openParen identifier closeParen
+  aInstruction = at (identifier | decNumber)
+  cInstruction = assign? op jmp?
   
   assign = (
       "AMD"

--- a/simulator/src/languages/grammars/asm.ohm.js
+++ b/simulator/src/languages/grammars/asm.ohm.js
@@ -1,7 +1,7 @@
 const asm = `
 ASM <: Base {
   Root := ASM
-  ASM = IntermediateInstruction* instruction?
+  ASM = newline* IntermediateInstruction* instruction?
   
   instruction = label|aInstruction|cInstruction
   IntermediateInstruction = instruction newline+

--- a/simulator/src/languages/grammars/asm.ohm.js
+++ b/simulator/src/languages/grammars/asm.ohm.js
@@ -1,12 +1,10 @@
 const asm = `
 ASM <: Base {
   Root := ASM
-  ASM = newline* IntermediateInstruction* instruction?
+  ASM = intermediateInstruction* instruction?
   
   instruction = label|aInstruction|cInstruction
-  IntermediateInstruction = instruction newline+
-
-  space := ~"\\n" "\\x00".."\\x20"
+  intermediateInstruction = instruction space+
 
   label = openParen identifier closeParen
   aInstruction = at (identifier | decNumber)

--- a/web/src/pages/asm.tsx
+++ b/web/src/pages/asm.tsx
@@ -12,7 +12,6 @@ import { Panel } from "../shell/panel";
 
 import { Link } from "react-router-dom";
 import { AppContext } from "src/App.context";
-import { useDialog } from "src/shell/dialog";
 import URLs from "src/urls";
 import "./asm.scss";
 
@@ -25,8 +24,6 @@ export const Asm = () => {
 
   const runner = useRef<Timer>();
   const [runnerAssigned, setRunnerAssigned] = useState(false);
-
-  const dialog = useDialog();
 
   useEffect(() => {
     if (toolStates.asmState) {
@@ -126,6 +123,12 @@ export const Asm = () => {
     actions.setAnimate(speed <= 2);
   };
 
+  const loadToCpu = async () => {
+    const bytes = await loadHack(state.result);
+    toolStates.setCpuState(state.asmName?.replace(".asm", ".hack"), bytes);
+    redirectRef.current?.click();
+  };
+
   return (
     <div className="AsmPage grid">
       <Panel
@@ -204,53 +207,21 @@ export const Asm = () => {
             </div>
             <div>
               <a ref={fileDownloadRef} style={{ display: "none" }} />
+              <Link
+                ref={redirectRef}
+                style={{ display: "none" }}
+                to={URLs["cpu"].href}
+              />
               <fieldset role="group">
-                <button onClick={dialog.open}>📂</button>
+                <button
+                  data-tooltip="Load to the CPU Emulator"
+                  data-placement="bottom"
+                  onClick={loadToCpu}
+                >
+                  ↩️
+                </button>
+                <button onClick={download}>Download</button>
               </fieldset>
-              <dialog open={dialog.isOpen}>
-                <article>
-                  <header
-                    style={{ display: "flex", flexDirection: "row-reverse" }}
-                  >
-                    <a
-                      style={{ color: "rgba(0, 0, 0, 0)" }}
-                      className="close"
-                      href="#root"
-                      onClick={(e) => {
-                        e.preventDefault();
-                        dialog.close();
-                      }}
-                    />
-                  </header>
-                  <main>
-                    <button
-                      onClick={() => {
-                        download();
-                        dialog.close();
-                      }}
-                    >
-                      Download
-                    </button>
-                    <Link
-                      ref={redirectRef}
-                      style={{ display: "none" }}
-                      to={URLs["cpu"].href}
-                    />
-                    <button
-                      onClick={async () => {
-                        const bytes = await loadHack(state.result);
-                        toolStates.setCpuState(
-                          state.asmName?.replace(".asm", ".hack"),
-                          bytes
-                        );
-                        redirectRef.current?.click();
-                      }}
-                    >
-                      Load in CPU Emulator
-                    </button>
-                  </main>
-                </article>
-              </dialog>
             </div>
           </>
         }


### PR DESCRIPTION
Before the change, the assembler would allow for 2 instructions to be on the same line,
and would accept spaces between instruction parts, i.e `@ 2`