### PR TITLE
Fix builtin ROM32K input pin width

### DIFF
--- a/simulator/src/chip/builtins/computer/computer.tsx
+++ b/simulator/src/chip/builtins/computer/computer.tsx
@@ -27,7 +27,7 @@ import { RAM, RAM16K } from "../sequential/ram.js";
 
 export class ROM32K extends RAM {
   constructor() {
-    super(16, "ROM");
+    super(15, "ROM");
   }
 
   override async load(fs: FileSystem, path: string) {


### PR DESCRIPTION
The address pin of the ROM32K chip was 16-bit wide (instead of 15), causing valid Computer.hdl implementations to not compile.