### PR TITLE
Allow DM,ADM as assembly destinations

### DIFF
--- a/simulator/src/languages/asm.ts
+++ b/simulator/src/languages/asm.ts
@@ -90,11 +90,16 @@ asmSemantics.addAttribute<AsmInstruction>("instruction", {
     return A(name.value, span(this.source));
   },
   CInstruction(assignN, opN, jmpN): AsmCInstruction {
-    const assign = (assignN.child(0)?.child(0)?.sourceString ??
-      "") as ASSIGN_ASM;
+    let assign = assignN.child(0)?.child(0)?.sourceString ?? "";
+    if (assign == "DM") {
+      assign = "MD";
+    }
+    if (assign == "ADM") {
+      assign = "AMD";
+    }
     const op = opN.sourceString as COMMANDS_ASM;
     const jmp = (jmpN.child(0)?.child(1)?.sourceString ?? "") as JUMP_ASM;
-    return C(assign, op, jmp, span(this.source));
+    return C(assign as ASSIGN_ASM, op, jmp, span(this.source));
   },
   Label(_o, { name }, _c): AsmLabelInstruction {
     return L(name, span(this.source));

--- a/simulator/src/languages/grammars/asm.ohm
+++ b/simulator/src/languages/grammars/asm.ohm
@@ -9,10 +9,10 @@ ASM <: Base {
   CInstruction = assign? op jmp?
   
   assign = (
-      "AMD"
+      "AMD" | "ADM"
       | "AM"
       | "AD"
-      | "MD"
+      | "MD" | "DM"
       | "M"
       | "D"
       | "A"

--- a/simulator/src/languages/grammars/asm.ohm
+++ b/simulator/src/languages/grammars/asm.ohm
@@ -8,6 +8,8 @@ ASM <: Base {
   AInstruction = at (identifier | decNumber)
   CInstruction = assign? op jmp?
   
+  /* The book (figure 4.5) specifies DM and ADM as the correct forms for destination,
+     but since the desktop simulators accept only MD and AMD we have decided to accept both */
   assign = (
       "AMD" | "ADM"
       | "AM"

--- a/simulator/src/languages/grammars/asm.ohm.js
+++ b/simulator/src/languages/grammars/asm.ohm.js
@@ -9,6 +9,8 @@ ASM <: Base {
   AInstruction = at (identifier | decNumber)
   CInstruction = assign? op jmp?
   
+  /* The book (figure 4.5) specifies DM and ADM as the correct forms for destination,
+     but since the desktop simulators accept only MD and AMD we have decided to accept both */
   assign = (
       "AMD" | "ADM"
       | "AM"

--- a/simulator/src/languages/grammars/asm.ohm.js
+++ b/simulator/src/languages/grammars/asm.ohm.js
@@ -10,10 +10,10 @@ ASM <: Base {
   CInstruction = assign? op jmp?
   
   assign = (
-      "AMD"
+      "AMD" | "ADM"
       | "AM"
       | "AD"
-      | "MD"
+      | "MD" | "DM"
       | "M"
       | "D"
       | "A"


### PR DESCRIPTION
This is the intended form as described in the book,
but the desktop simulator has it the other way around,
so Shimon proposed we support both forms.