### PR TITLE
Fix header tooltip being cropped

### DIFF
--- a/web/src/pico/icon.scss
+++ b/web/src/pico/icon.scss
@@ -5,7 +5,10 @@
 
 ul.icon-list {
   margin-right: 0.4rem;
-  overflow-x: auto;
+
+  @media (max-width: 576px) {
+    overflow: auto;
+  }
 
   li {
     display: flex;


### PR DESCRIPTION
A recent change aimed at making the header scrollable on mobile resulted in the tooltips being cropped.