### PR TITLE
Bug fix: builtin only chips keep resetting on firefox

### DIFF
--- a/components/src/stores/chip.store.ts
+++ b/components/src/stores/chip.store.ts
@@ -314,10 +314,6 @@ export function makeChipStore(
       );
 
       if (builtinOnly) {
-        dispatch.current({
-          action: "setFiles",
-          payload: { hdl: "", tst: "", cmp: "" },
-        });
         this.useBuiltin();
       } else {
         await this.loadChip(project, chipName);


### PR DESCRIPTION
Bug report from Coursera forum:
![Screenshot from 2024-06-05 17-36-54](https://github.com/nand2tetris/web-ide/assets/67196883/c4ae376e-4450-47f2-b5c6-b174ddfa713d)

Explanation: the removed reset caused the `useEffect` in https://github.com/nand2tetris/web-ide/blob/main/web/src/pages/chip.tsx#L94 to loop indefinitely.