### PR TITLE
Fix color shceme of file picker in dark theme

### DIFF
--- a/web/src/pico/pico.scss
+++ b/web/src/pico/pico.scss
@@ -31,6 +31,7 @@
     --mark-background-color: rgb(255, 230, 121);
     --mark-error-color: rgb(252, 169, 154);
     --light-grey: rgb(170, 170, 170);
+    --disabled: var(--light-grey);
     --file-picker-width: 400px;
   }
 
@@ -46,6 +47,12 @@
     --card-border-color: white;
     --text-color: white;
     --mark-background-color: rgb(30, 74, 109);
+
+    .outline {
+      color: var(--light-grey);
+    }
+
+    --disabled: rgb(76, 85, 93);
   }
 }
 

--- a/web/src/shell/file_select.tsx
+++ b/web/src/shell/file_select.tsx
@@ -95,7 +95,7 @@ const FileEntry = ({
         }`}
         style={{
           textAlign: "left",
-          color: disabled ? "var(--light-grey)" : undefined,
+          color: disabled ? "var(--disabled)" : undefined,
         }}
         onClick={onClickCB}
       >


### PR DESCRIPTION
Closes #359 

File picker will now look like this in the example provided in the issue:
![Screenshot from 2024-06-11 13-08-10](https://github.com/nand2tetris/web-ide/assets/67196883/f60852b2-dc90-46a4-a8d5-2b33edaf71e1)
