### PR TITLE
Add meta tags to disable page caching by browser

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -5,6 +5,9 @@
     <title>NAND2Tetris</title>
     <meta name="description" content="NAND2Tetris Web IDE" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv='cache-control' content='no-cache'> 
+    <meta http-equiv='expires' content='0'> 
+    <meta http-equiv='pragma' content='no-cache'>
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link
       rel="shortcut icon"

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -5,9 +5,7 @@
     <title>NAND2Tetris</title>
     <meta name="description" content="NAND2Tetris Web IDE" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta http-equiv="cache-control" content="no-cache" />
-    <meta http-equiv="expires" content="0" />
-    <meta http-equiv="pragma" content="no-cache" />
+    <meta http-equiv="Cache-Control" content="no-cache" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link
       rel="shortcut icon"

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -5,9 +5,9 @@
     <title>NAND2Tetris</title>
     <meta name="description" content="NAND2Tetris Web IDE" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta http-equiv='cache-control' content='no-cache'> 
-    <meta http-equiv='expires' content='0'> 
-    <meta http-equiv='pragma' content='no-cache'>
+    <meta http-equiv="cache-control" content="no-cache" />
+    <meta http-equiv="expires" content="0" />
+    <meta http-equiv="pragma" content="no-cache" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link
       rel="shortcut icon"


### PR DESCRIPTION
It seems like the IDE doesn't update even after deployment, and only updates when you clear the browser cache.
Hopefully this will solve the issue.
([Source](https://github.com/orgs/community/discussions/19713))