### PR TITLE
Remove load commands from asm tests of project 7,8

### DIFF
--- a/projects/src/project_07/11_simple_add.ts
+++ b/projects/src/project_07/11_simple_add.ts
@@ -37,7 +37,6 @@ export const hdl_tst = `// This file is part of www.nand2tetris.org
 
 // Tests SimpleAdd.asm on the CPU emulator.
 
-load SimpleAdd.asm,
 compare-to SimpleAdd.cmp,
 
 set RAM[0] 256,  // initializes the stack pointer 

--- a/projects/src/project_07/12_stack_test.ts
+++ b/projects/src/project_07/12_stack_test.ts
@@ -76,7 +76,6 @@ export const hdl_tst = `// This file is part of www.nand2tetris.org
 
 // Tests StackTest.asm on the CPU emulator.
 
-load StackTest.asm,
 compare-to StackTest.cmp,
 
 set RAM[0] 256,  // initializes the stack pointer

--- a/projects/src/project_07/21_basic_test.ts
+++ b/projects/src/project_07/21_basic_test.ts
@@ -68,7 +68,6 @@ export const hdl_tst = `// This file is part of www.nand2tetris.org
 
 // Tests BasicTest.asm on the CPU emulator.
 
-load BasicTest.asm,
 compare-to BasicTest.cmp,
 
 set RAM[0] 256,   // stack pointer

--- a/projects/src/project_07/22_pointer_test.ts
+++ b/projects/src/project_07/22_pointer_test.ts
@@ -53,7 +53,6 @@ export const hdl_tst = `// This file is part of www.nand2tetris.org
 
 // Tests PointerTest.asm on the CPU emulator.
 
-load PointerTest.asm,
 compare-to PointerTest.cmp,
 
 set RAM[0] 256,   // initializes the stack pointer

--- a/projects/src/project_07/23_static_test.ts
+++ b/projects/src/project_07/23_static_test.ts
@@ -46,7 +46,6 @@ export const hdl_tst = `// This file is part of www.nand2tetris.org
 
 // Tests StaticTest.asm on the CPU emulator.
 
-load StaticTest.asm,
 compare-to StaticTest.cmp,
 
 set RAM[0] 256,    // initializes the stack pointer

--- a/projects/src/project_08/11_basic_loop.ts
+++ b/projects/src/project_08/11_basic_loop.ts
@@ -60,7 +60,6 @@ export const hdl_tst = `// This file is part of www.nand2tetris.org
 // and the base addresses of the local and argument segments,
 // and sets argument[0].
 
-load BasicLoop.asm,
 compare-to BasicLoop.cmp,
 
 set RAM[0] 256,  // SP

--- a/projects/src/project_08/12_fibonacci_series.ts
+++ b/projects/src/project_08/12_fibonacci_series.ts
@@ -84,7 +84,6 @@ export const hdl_tst = `// This file is part of www.nand2tetris.org
 // and the base addresses of the local and argument segments,
 // and sets argument[0] and argument [1].
 
-load FibonacciSeries.asm,
 compare-to FibonacciSeries.cmp,
 
 set RAM[0] 256,    // SP

--- a/projects/src/project_08/20_simple_function.ts
+++ b/projects/src/project_08/20_simple_function.ts
@@ -66,7 +66,6 @@ export const hdl_tst = `// This file is part of www.nand2tetris.org
 // Before executing the code, initializes the stack pointer and the pointers of some
 // of the memory segments, and sets some values in the argument segment.
 
-Load SimpleFunction.asm,
 compare-to SimpleFunction.cmp,
 
 set RAM[0] 317,    // SP

--- a/projects/src/project_08/21_nested_call.ts
+++ b/projects/src/project_08/21_nested_call.ts
@@ -136,7 +136,6 @@ export const hdl_tst = `// Tests how the VM implementation handles function-call
 // the VM translator is applied to the NestedCall folder, which 
 // includes only one VM file: Sys.vm.
 
-load NestedCall.asm,
 compare-to NestedCall.cmp,
 
 set RAM[0] 261,

--- a/projects/src/project_08/22_fibonacci_element.ts
+++ b/projects/src/project_08/22_fibonacci_element.ts
@@ -81,7 +81,6 @@ export const hdl_tst = `// This file is part of www.nand2tetris.org
 // FibonacciElement.asm results from translating Main.vm and Sys.vm into
 // a single assembly program, stored in the file FibonacciElement.asm.
 
-load FibonacciElement.asm,
 compare-to FibonacciElement.cmp,
 
 repeat 6000 {

--- a/projects/src/project_08/23_statics_test.ts
+++ b/projects/src/project_08/23_statics_test.ts
@@ -90,7 +90,6 @@ export const hdl_tst = `// This file is part of www.nand2tetris.org
 // Tests StaticTest.asm in the CPU emulator.
 // This assembly file results from translating the staticsTest folder.
 
-load StaticsTest.asm,
 compare-to StaticsTest.cmp,
 
 set RAM[0] 256,


### PR DESCRIPTION
These are the files generated by the student's VM translator and will have to be loaded manually.