### PR TITLE
Fix diff table colors in dark mode

### DIFF
--- a/web/src/shell/editor.scss
+++ b/web/src/shell/editor.scss
@@ -16,22 +16,27 @@
 
   .error-highlight {
     background-color: var(--mark-error-color);
+    color: black;
   }
 
   .diff-highlight-line-1 {
     background-color: #ffebe9;
+    color: black;
   }
 
   .diff-highlight-cell-1 {
     background-color: #ffc1c0;
+    color: black;
   }
 
   .diff-highlight-line-2 {
     background-color: #dafbe1;
+    color: black;
   }
 
   .diff-highlight-cell-2 {
     background-color: #aceebb;
+    color: black;
   }
 
   textarea {


### PR DESCRIPTION
The red and green colors in the diff table lack contrast in dark mode. 
Made the text black so that it's visible in both - light and dark mode

Before:
<img width="730" alt="image" src="https://github.com/user-attachments/assets/f3905149-9215-4df2-a578-ca5540c154f4">

After:
<img width="718" alt="image" src="https://github.com/user-attachments/assets/dddb87b9-5804-4fbf-bf0b-dbe2bcfb5695">
