### PR TITLE
Improve compiler error tab color for dark theme

### DIFF
--- a/web/src/pages/compiler.tsx
+++ b/web/src/pages/compiler.tsx
@@ -210,7 +210,7 @@ export const Compiler = () => {
               onSelect={() => onSelect(file)}
               style={{
                 backgroundColor: !state.compiled[file].valid
-                  ? "#ffaaaa"
+                  ? "var(--compiler-err-color)"
                   : undefined,
               }}
             >

--- a/web/src/pico/pico.scss
+++ b/web/src/pico/pico.scss
@@ -31,6 +31,7 @@
     --mark-background-color: rgb(255, 230, 121);
     --mark-error-color: rgb(252, 169, 154);
     --light-grey: rgb(170, 170, 170);
+    --compiler-err-color: "#ffaaaa";
     --disabled: var(--light-grey);
     --file-picker-width: 400px;
   }
@@ -47,6 +48,7 @@
     --card-border-color: white;
     --text-color: white;
     --mark-background-color: rgb(30, 74, 109);
+    --compiler-err-color: rgb(69, 25, 22);
 
     .outline {
       color: var(--light-grey);


### PR DESCRIPTION
before:
![Screenshot from 2024-09-16 16-18-31](https://github.com/user-attachments/assets/d9e095ea-2264-42b2-8e6f-d16c22534a1c)
after:
![Screenshot from 2024-09-16 16-18-18](https://github.com/user-attachments/assets/b8e04b3f-cd1e-46c3-85dc-af27e7981649)
