### PR TITLE
Fix compiler page offset when having too much tabs

### DIFF
--- a/web/src/shell/tab.scss
+++ b/web/src/shell/tab.scss
@@ -63,8 +63,8 @@ label[role="tab"],
 }
 
 [role="tab"] [type="radio"] {
-  /* Leave the radio button focusable, but not visible. Copied from .screen-reader-text */
-  display: none;
+  opacity: 0; // keep the radio button focusable, but not visible, to allow switching tabs with the arrow keys
+  margin-inline: -7px; // offset the gap created by the invisible radio button (7px value was adjusted experimentally)
 }
 
 [role="tab"][aria-selected="true"] {

--- a/web/src/shell/tab.scss
+++ b/web/src/shell/tab.scss
@@ -64,11 +64,7 @@ label[role="tab"],
 
 [role="tab"] [type="radio"] {
   /* Leave the radio button focusable, but not visible. Copied from .screen-reader-text */
-  clip: rect(1px, 1px, 1px, 1px);
-  position: absolute !important;
-  height: 1px;
-  width: 1px;
-  overflow: hidden;
+  display: none;
 }
 
 [role="tab"][aria-selected="true"] {


### PR DESCRIPTION
Fixes #451 

the line ` position: absolute !important;` caused the issue.
`disply: none;` achieves the same effect.