### PR TITLE
Fix symbol table text color for dark theme

### DIFF
--- a/components/src/table.tsx
+++ b/components/src/table.tsx
@@ -58,7 +58,6 @@ const TableRow = ({
           style={{
             flex: "1",
             textAlign: "right",
-            color: "black",
             padding: "3px",
             ...rounded("none"),
             ...(highlight

--- a/web/src/pico/pico.scss
+++ b/web/src/pico/pico.scss
@@ -49,6 +49,7 @@
     --text-color: white;
     --mark-background-color: rgb(30, 74, 109);
     --compiler-err-color: rgb(69, 25, 22);
+    --code-color: rgb(180, 180, 180);
 
     .outline {
       color: var(--light-grey);


### PR DESCRIPTION
before:
![Screenshot from 2024-09-17 10-30-32](https://github.com/user-attachments/assets/59b8a411-197f-446a-a30b-6794b7afc75c)
after:
![Screenshot from 2024-09-17 10-30-08](https://github.com/user-attachments/assets/3b0b8afc-2cf8-486b-86f1-504fd0df0b0a)
