### PR TITLE
fix: #498 allow Zero-sized strings in VM.

### DIFF
--- a/simulator/src/vm/os/string.ts
+++ b/simulator/src/vm/os/string.ts
@@ -31,7 +31,7 @@ export class StringLib {
   }
 
   new(size: number) {
-    if (size <= 0) {
+    if (size < 0) {
       this.os.sys.error(ERRNO.STRING_LENGTH_NEG);
     }
     const pointer = this.os.memory.alloc(size + 2); // +2 to save length, maxLength fields


### PR DESCRIPTION
The vm call `String.new` now only checks if `size` is negative, so that empty strings work as expected.