### PR TITLE
Update sorting for chips projects

### DIFF
--- a/projects/src/base.ts
+++ b/projects/src/base.ts
@@ -220,7 +220,7 @@ export const VM_PROJECTS: Record<"07" | "08", string[]> = {
 };
 
 function partitionChips(project: "01" | "02" | "03" | "05", chips: string[]) {
-  const base = CHIP_PROJECTS["01"];
+  const base = CHIP_PROJECTS[project];
   // Get all the default project chips, in order, and remove those that aren't in `chips`.
   const core = base.filter((name) => chips.includes(name));
   // Get all the chips that aren't in base.
@@ -237,7 +237,7 @@ export function sortChips(project: string, chips: string[]): string[] {
     }
     case "2":
     case "02": {
-      return partitionChips("01", chips);
+      return partitionChips("02", chips);
     }
     case "3":
     case "03": {


### PR DESCRIPTION
https://github.com/nand2tetris/web-ide/commit/eb5f60496a2490c82e1ac91d4de5943038d42282 broke recommended order for chips projects after project 01 (e.g. 2, 3, 5) and instead alphabetically sorts them.

See 
![image](https://github.com/user-attachments/assets/4f734b3d-4f2b-4891-a9ec-42d6df391115)


Correct/Fixed output
![image](https://github.com/user-attachments/assets/09fc3dc7-9ca3-4c42-8e47-46604eba3d4e)
