### PR TITLE
Fix #523: Cpu emulator test runner doesn't recognize asm from assembler page

### DIFF
--- a/simulator/src/cpu/memory.ts
+++ b/simulator/src/cpu/memory.ts
@@ -127,6 +127,10 @@ export class Memory implements MemoryAdapter {
   [Symbol.iterator](): Iterable<number> {
     return this.map((_, v) => v);
   }
+
+  isEmpty(): boolean {
+    return this.memory.every((word) => word === 0);
+  }
 }
 
 export class SubMemory implements MemoryAdapter {

--- a/simulator/src/test/cputst.ts
+++ b/simulator/src/test/cputst.ts
@@ -55,7 +55,7 @@ export class CPUTest extends Test<CPUTestInstruction> {
   }
 
   override async step() {
-    if (!(this.hasLoad || this.fileLoaded)) {
+    if (!this.hasLoad && this.cpu.ROM.isEmpty()) {
       throw new Error(
         "Cannot execute the test without first loading an .asm or .hack file",
       );


### PR DESCRIPTION
Added isEmpty() to Memory class
check for ROM.isEmpty() instead of fileLoaded in cputst.step()