### PR TITLE
fix #495: VM emulator ignores Sys.wait

### DIFF
--- a/simulator/src/vm/os/sys.ts
+++ b/simulator/src/vm/os/sys.ts
@@ -57,7 +57,7 @@ export class SysLib {
     this.block();
 
     (async () => {
-      await new Promise(x => setTimeout(x, ms));
+      await new Promise((x) => setTimeout(x, ms));
       this.release();
     })();
   }

--- a/simulator/src/vm/os/sys.ts
+++ b/simulator/src/vm/os/sys.ts
@@ -53,25 +53,13 @@ export class SysLib {
       this.error(ERRNO.SYS_WAIT_DURATION_NOT_POSITIVE);
       return;
     }
+
     this.block();
 
-    let waited = 0;
-
-    const loop = (delta: number) => {
-      if (this.cancelWait) {
-        return;
-      }
-
-      waited += delta;
-
-      if (waited >= ms) {
-        this.release();
-      } else {
-        this.animationFrameId = requestAnimationFrame(loop);
-      }
-    };
-
-    loop(0);
+    (async () => {
+      await new Promise(x => setTimeout(x, ms));
+      this.release();
+    })();
   }
 
   halt() {


### PR DESCRIPTION
The Sys.wait instruction used to utilize a simple loop that looped `ms` times. Because the execution speed differs a lot, depending on the computer and browser, the wait instruction didn't seem to wait at all.

I guess, the better solution is, to use a javascript timeout, so the wait time will be consistent in all configurations.