### PR TITLE
fix #526: vm emulator raises "call stack exceeded"…

### DIFF
--- a/simulator/src/vm/os/output.ts
+++ b/simulator/src/vm/os/output.ts
@@ -49,7 +49,7 @@ export class OutputLib {
   }
 
   println() {
-    this.row += 1;
+    this.row = this.row == MAX_HEIGHT ? 0 : this.row + 1;
     this.col = 0;
   }
 
@@ -83,9 +83,6 @@ export class OutputLib {
     this.col += 1;
     if (this.col == MAX_WIDTH) {
       this.println();
-      if (this.row == MAX_HEIGHT) {
-        this.row = 0;
-      }
     }
   }
 


### PR DESCRIPTION
… when doing println in last row

The check for printing past the end of the VM screen was only done in Output.printChar(). So, when an Output.println() command was executed in the last row of the virtual screen, a "call stack exceeded" error message was shown.

I moved the check to the println function, so the cursor will just wrap around to row 0, as intended, when a println occurs in the last line (either by an Output.println() command or by printing past the end of the last line