### PR TITLE
Adjust width of some buttons on the Settings dialog

### DIFF
--- a/web/src/shell/settings.scss
+++ b/web/src/shell/settings.scss
@@ -1,5 +1,5 @@
 .settings-dialog {
-    [role="button"] {
-        width: 100%;
-    }
+  [role="button"] {
+    width: 100%;
+  }
 }

--- a/web/src/shell/settings.scss
+++ b/web/src/shell/settings.scss
@@ -1,0 +1,5 @@
+.settings-dialog {
+    [role="button"] {
+        width: 100%;
+    }
+}

--- a/web/src/shell/settings.tsx
+++ b/web/src/shell/settings.tsx
@@ -8,6 +8,7 @@ import { useDialog } from "@nand2tetris/components/dialog";
 import { PageContext } from "src/Page.context";
 import "../pico/button-group.scss";
 import "../pico/property.scss";
+import "./settings.scss";
 import { TrackingDisclosure } from "../tracking";
 import { getVersion, setVersion } from "../versions";
 
@@ -172,7 +173,7 @@ export const Settings = () => {
   return (
     <>
       <dialog open={settings.isOpen}>
-        <article>
+        <article className="settings-dialog">
           <header>
             <p>
               <Trans>Settings</Trans>


### PR DESCRIPTION
currently some of the "buttons" on the settings dialog are actualy <a> with role="button" and as so - have a different style than the other buttons on this menu. This PR adjusts this issue, while adding a new "settings.scss" file for these (and possibly future) settings related styles.

before change -
![non full width buttons](https://github.com/user-attachments/assets/5f29f2b5-8cd5-4660-85c5-b55336bc34ef)

after change - 
![full width buttons](https://github.com/user-attachments/assets/02648b7e-f68b-468c-bc16-a86ea9fc6c72)
