### PR TITLE
VM SP off by one

### DIFF
--- a/projects/src/project_08/22_fibonacci_element.ts
+++ b/projects/src/project_08/22_fibonacci_element.ts
@@ -60,7 +60,7 @@ export const vm_tst = `// This file is part of www.nand2tetris.org
 load,
 compare-to FibonacciElement.cmp,
 
-set sp 261,
+set sp 262,
 
 repeat 110 {
   vmstep;
@@ -89,10 +89,10 @@ repeat 6000 {
 
 // Outputs the stack pointer and the value at the stack's base.
 // That's where the implementation should put the return value.
-output-list RAM[0]%D1.6.1 RAM[261]%D1.6.1;
+output-list RAM[0]%D1.6.1 RAM[262]%D1.6.1;
 output;
 `;
 
-export const cmp = `| RAM[0] |RAM[261]|
-|    262 |      3 |
+export const cmp = `| RAM[0] |RAM[262]|
+|    263 |      3 |
 `;


### PR DESCRIPTION
VM test script should set SP to be 262, not 261, to agree with assembler version. 

In the assembler version, SP=256 at the start.
Then the stack upon calling the Fibonacci function for the first time contains:
* n=4 is the argument to Fibonacci
* return address
* args, local, this, that
That means SP=262 at the start of the function call.

