### PR TITLE
Add a status line background color

### DIFF
--- a/components/src/chips/memory.tsx
+++ b/components/src/chips/memory.tsx
@@ -258,7 +258,10 @@ export const Memory = forwardRef(
               );
               jumpTo();
             } catch (e) {
-              setStatus(`Error loading memory: ${(e as Error).message}`);
+              setStatus({
+                message: `Error loading memory: ${(e as Error).message}`,
+                severity: "ERROR",
+              });
               return;
             }
           });

--- a/components/src/stores/asm.store.ts
+++ b/components/src/stores/asm.store.ts
@@ -25,7 +25,7 @@ import { bin } from "@nand2tetris/simulator/util/twos.js";
 import { Dispatch, MutableRefObject, useContext, useMemo, useRef } from "react";
 import { RunSpeed } from "src/runbar.js";
 import { useImmerReducer } from "../react.js";
-import { BaseContext } from "./base.context.js";
+import { BaseContext, StatusSeverity } from "./base.context.js";
 
 export interface TranslatorSymbol {
   name: string;
@@ -198,7 +198,7 @@ export type AsmStoreDispatch = Dispatch<{
 
 export function makeAsmStore(
   fs: FileSystem,
-  setStatus: Action<string>,
+  setStatus: Action<string | { message: string; severity?: StatusSeverity }>,
   dispatch: MutableRefObject<AsmStoreDispatch>,
   upgraded: boolean,
 ) {
@@ -234,7 +234,10 @@ export function makeAsmStore(
 
     setError(state: AsmPageState, error?: CompilationError) {
       if (error) {
-        setStatus(error.message);
+        setStatus({
+          message: error.message,
+          severity: "ERROR",
+        });
       }
       state.error = error;
     },
@@ -258,13 +261,19 @@ export function makeAsmStore(
 
       if (resultLines.length != compareLines.length) {
         failure = true;
-        setStatus("Comparison failed - different lengths");
+        setStatus({
+          message: "Comparison failed - different lengths",
+          severity: "ERROR",
+        });
         return;
       }
 
       for (let i = 0; i < compareLines.length; i++) {
         if (resultLines[i] !== compareLines[i]) {
-          setStatus(`Comparison failure: Line ${i}`);
+          setStatus({
+            message: `Comparison failure: Line ${i}`,
+            severity: "ERROR",
+          });
 
           failure = true;
           highlightInfo.resultHighlight = {
@@ -275,7 +284,10 @@ export function makeAsmStore(
           return;
         }
       }
-      setStatus("Comparison successful");
+      setStatus({
+        message: "Comparison successful",
+        severity: "SUCCESS",
+      });
     },
 
     setTitle(state: AsmPageState, title: string) {
@@ -366,7 +378,10 @@ export function makeAsmStore(
       }
 
       if (translator.done) {
-        setStatus("Translation done.");
+        setStatus({
+          message: "Translation done.",
+          severity: "SUCCESS",
+        });
       }
       return translator.done;
     },

--- a/components/src/stores/base.context.ts
+++ b/components/src/stores/base.context.ts
@@ -22,14 +22,16 @@ import {
   removeLocalAdapterFromIndexedDB,
 } from "./base/indexDb.js";
 
+export type StatusSeverity = "SUCCESS" | "WARNING" | "ERROR" | "INFO";
+
 export interface BaseContext {
   fs: FileSystem;
   localFsRoot?: string;
   canUpgradeFs: boolean;
   upgradeFs: (force?: boolean, createFiles?: boolean) => Promise<void>;
   closeFs: () => void;
-  status: string;
-  setStatus: Action<string>;
+  status: { message: string; severity: StatusSeverity };
+  setStatus: Action<string | { message: string; severity?: StatusSeverity }>;
   storage: Record<string, string>;
   permissionPrompt: ReturnType<typeof useDialog>;
   requestPermission: AsyncAction<void>;
@@ -98,9 +100,11 @@ export function useBaseContext(): BaseContext {
             permissionPrompt.open();
             break;
           case "denied":
-            setStatus(
-              "Permission denied. Please allow access to your file system.",
-            );
+            setStatus({
+              message:
+                "Permission denied. Please allow access to your file system.",
+              severity: "ERROR",
+            });
             break;
         }
       });
@@ -129,7 +133,24 @@ export function useBaseContext(): BaseContext {
     setFs(new FileSystem(localAdapter));
   }, [root]);
 
-  const [status, setStatus] = useState("");
+  const [status, setStatusInternal] = useState<{
+    message: string;
+    severity: StatusSeverity;
+  }>({ message: "", severity: "INFO" });
+
+  const setStatus = useCallback(
+    (input: string | { message: string; severity?: StatusSeverity }) => {
+      if (typeof input === "string") {
+        setStatusInternal({ message: input, severity: "INFO" });
+      } else {
+        setStatusInternal({
+          message: input.message,
+          severity: input.severity || "INFO",
+        });
+      }
+    },
+    [],
+  );
 
   return {
     fs,
@@ -153,7 +174,7 @@ export const BaseContext = createContext<BaseContext>({
   async upgradeFs() {},
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   closeFs() {},
-  status: "",
+  status: { message: "", severity: "INFO" },
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   setStatus() {},
   storage: {},

--- a/components/src/stores/chip.store.ts
+++ b/components/src/stores/chip.store.ts
@@ -31,7 +31,7 @@ import { Action } from "@nand2tetris/simulator/types.js";
 import { compare } from "../compare.js";
 import { sortFiles } from "../file_utils.js";
 import { RunSpeed } from "../runbar.js";
-import { BaseContext } from "./base.context.js";
+import { BaseContext, StatusSeverity } from "./base.context.js";
 
 export const NO_SCREEN = "noScreen";
 
@@ -128,7 +128,7 @@ export type ChipStoreDispatch = Dispatch<{
 
 export function makeChipStore(
   fs: FileSystem,
-  setStatus: Action<string>,
+  setStatus: Action<string | { message: string; severity?: StatusSeverity }>,
   storage: Record<string, string>,
   dispatch: MutableRefObject<ChipStoreDispatch>,
   upgraded: boolean,
@@ -234,8 +234,14 @@ export function makeChipStore(
       Promise.resolve().then(() => {
         setStatus(
           passed
-            ? `Simulation successful: The output file is identical to the compare file`
-            : `Simulation error: The output file differs from the compare file`,
+            ? {
+                message: `Simulation successful: The output file is identical to the compare file`,
+                severity: "SUCCESS",
+              }
+            : {
+                message: `Simulation error: The output file differs from the compare file`,
+                severity: "ERROR",
+              },
         );
       });
     },
@@ -376,7 +382,10 @@ export function makeChipStore(
       const maybeChip = await parseChip(hdl, dir, name, fs);
       if (isErr(maybeChip)) {
         const error = Err(maybeChip);
-        setStatus(Err(maybeChip).message);
+        setStatus({
+          message: Err(maybeChip).message,
+          severity: "ERROR",
+        });
         invalid = true;
         dispatch.current({
           action: "updateChip",
@@ -420,9 +429,10 @@ export function makeChipStore(
         dispatch.current({ action: "setTest", payload: name });
         this.compileTest(tst, dir);
       } catch (e) {
-        setStatus(
-          `Could not find ${name}.tst. Please load test file separately.`,
-        );
+        setStatus({
+          message: `Could not find ${name}.tst. Please load test file separately.`,
+          severity: "WARNING",
+        });
         console.error(e);
       }
     },
@@ -432,7 +442,10 @@ export function makeChipStore(
       dispatch.current({ action: "setFiles", payload: { tst: file } });
       const tst = TST.parse(file);
       if (isErr(tst)) {
-        setStatus(`Failed to parse test ${Err(tst).message}`);
+        setStatus({
+          message: `Failed to parse test ${Err(tst).message}`,
+          severity: "ERROR",
+        });
         invalid = true;
         return false;
       }
@@ -450,7 +463,10 @@ export function makeChipStore(
       });
       if (isErr(maybeTest)) {
         invalid = true;
-        setStatus(Err(maybeTest).message);
+        setStatus({
+          message: Err(maybeTest).message,
+          severity: "ERROR",
+        });
         return false;
       } else {
         test = Ok(maybeTest).with(chip).reset();
@@ -481,7 +497,10 @@ export function makeChipStore(
           this.compileTest(tst, tstPath ?? _dir);
         }
       } catch (e) {
-        setStatus(display(e));
+        setStatus({
+          message: display(e),
+          severity: "ERROR",
+        });
       }
       dispatch.current({ action: "updateChip", payload: { invalid: invalid } });
       if (!invalid) {
@@ -527,9 +546,10 @@ export function makeChipStore(
       const builtinName = _chipName;
       const nextChip = await getBuiltinChip(builtinName);
       if (isErr(nextChip)) {
-        setStatus(
-          `Failed to load builtin ${builtinName}: ${display(Err(nextChip))}`,
-        );
+        setStatus({
+          message: `Failed to load builtin ${builtinName}: ${display(Err(nextChip))}`,
+          severity: "ERROR",
+        });
         return;
       }
       this.replaceChip(Ok(nextChip));
@@ -558,7 +578,10 @@ export function makeChipStore(
         }
         return done;
       } catch (e) {
-        setStatus((e as Error).message);
+        setStatus({
+          message: (e as Error).message,
+          severity: "ERROR",
+        });
         return true;
       }
     },

--- a/components/src/stores/compiler.store.ts
+++ b/components/src/stores/compiler.store.ts
@@ -3,7 +3,7 @@ import { compile } from "@nand2tetris/simulator/jack/compiler.js";
 import { CompilationError } from "@nand2tetris/simulator/languages/base.js";
 import { Dispatch, MutableRefObject, useContext, useMemo, useRef } from "react";
 import { useImmerReducer } from "../react.js";
-import { BaseContext } from "./base.context.js";
+import { BaseContext, StatusSeverity } from "./base.context.js";
 import { Action } from "@nand2tetris/simulator/types.js";
 
 export interface CompiledFile {
@@ -32,7 +32,7 @@ function classTemplate(name: string) {
 }
 
 export function makeCompilerStore(
-  setStatus: Action<string>,
+  setStatus: Action<string | { message: string; severity?: StatusSeverity }>,
   dispatch: MutableRefObject<CompilerStoreDispatch>,
 ) {
   let fs: FileSystem | undefined;

--- a/components/src/stores/cpu.store.ts
+++ b/components/src/stores/cpu.store.ts
@@ -23,7 +23,7 @@ import { RunSpeed } from "src/runbar.js";
 import { compare } from "../compare.js";
 import { loadTestFiles } from "../file_utils.js";
 import { useImmerReducer } from "../react.js";
-import { BaseContext } from "./base.context.js";
+import { BaseContext, StatusSeverity } from "./base.context.js";
 import { ImmMemory } from "./imm_memory.js";
 
 function makeTst() {
@@ -95,7 +95,7 @@ export type CpuStoreDispatch = Dispatch<{
 
 export function makeCpuStore(
   fs: FileSystem,
-  setStatus: Action<string>,
+  setStatus: Action<string | { message: string; severity?: StatusSeverity }>,
   storage: Record<string, string>,
   dispatch: MutableRefObject<CpuStoreDispatch>,
 ) {
@@ -135,8 +135,14 @@ export function makeCpuStore(
       const passed = compare(state.test.cmp.trim(), test.log().trim());
       setStatus(
         passed
-          ? `Simulation successful: The output file is identical to the compare file`
-          : `Simulation error: The output file differs from the compare file`,
+          ? {
+              message: `Simulation successful: The output file is identical to the compare file`,
+              severity: "SUCCESS",
+            }
+          : {
+              message: `Simulation error: The output file differs from the compare file`,
+              severity: "ERROR",
+            },
       );
     },
 
@@ -192,7 +198,10 @@ export function makeCpuStore(
         }
         return done;
       } catch (e) {
-        setStatus((e as Error).message);
+        setStatus({
+          message: (e as Error).message,
+          severity: "ERROR",
+        });
         return true;
       }
     },
@@ -237,7 +246,10 @@ export function makeCpuStore(
       const tst = TST.parse(file);
 
       if (isErr(tst)) {
-        setStatus(`Failed to parse test - ${Err(tst).message}`);
+        setStatus({
+          message: `Failed to parse test - ${Err(tst).message}`,
+          severity: "ERROR",
+        });
         valid = false;
         dispatch.current({ action: "update" });
         return false;
@@ -273,7 +285,10 @@ export function makeCpuStore(
       });
 
       if (isErr(maybeTest)) {
-        setStatus(Err(maybeTest).message);
+        setStatus({
+          message: Err(maybeTest).message,
+          severity: "ERROR",
+        });
         return false;
       } else {
         test = Ok(maybeTest);
@@ -287,7 +302,10 @@ export function makeCpuStore(
       const dir = path.split("/").slice(0, -1).join("/");
       const files = await loadTestFiles(fs, `${dir}/${name}`);
       if (isErr(files)) {
-        setStatus(`Failed to load test`);
+        setStatus({
+          message: `Failed to load test`,
+          severity: "ERROR",
+        });
         return;
       }
       tstName = name;

--- a/components/src/stores/vm.store.ts
+++ b/components/src/stores/vm.store.ts
@@ -28,7 +28,7 @@ import { ScreenScales } from "../chips/screen.js";
 import { compare } from "../compare.js";
 import { useImmerReducer } from "../react.js";
 import { RunSpeed } from "../runbar.js";
-import { BaseContext } from "./base.context.js";
+import { BaseContext, StatusSeverity } from "./base.context.js";
 import { ImmMemory } from "./imm_memory.js";
 
 export const DEFAULT_TEST = "repeat {\n\tvmstep;\n}";
@@ -90,7 +90,7 @@ export type VmStoreDispatch = Dispatch<{
 function reduceVMTest(
   vmTest: VMTest,
   dispatch: MutableRefObject<VmStoreDispatch>,
-  setStatus: Action<string>,
+  setStatus: Action<string | { message: string; severity?: StatusSeverity }>,
   showHighlight: boolean,
 ): VmSim {
   const RAM = new ImmMemory(vmTest.vm.RAM, dispatch);
@@ -102,7 +102,10 @@ function reduceVMTest(
   try {
     stack = vmTest.vm.vmStack().reverse();
   } catch (e) {
-    setStatus("Runtime error: Invalid stack");
+    setStatus({
+      message: "Runtime error: Invalid stack",
+      severity: "ERROR",
+    });
   }
 
   return {
@@ -123,7 +126,7 @@ function reduceVMTest(
 
 export function makeVmStore(
   fs: FileSystem,
-  setStatus: Action<string>,
+  setStatus: Action<string | { message: string; severity?: StatusSeverity }>,
   storage: Record<string, string>,
   dispatch: MutableRefObject<VmStoreDispatch>,
 ) {
@@ -156,7 +159,10 @@ export function makeVmStore(
     setError(state: VmPageState, error?: CompilationError) {
       if (error) {
         state.controls.valid = false;
-        setStatus(error?.message);
+        setStatus({
+          message: error?.message,
+          severity: "ERROR",
+        });
       } else {
         state.controls.valid = true;
       }
@@ -176,8 +182,14 @@ export function makeVmStore(
       const passed = compare(state.files.cmp.trim(), state.files.out);
       setStatus(
         passed
-          ? `Simulation successful: The output file is identical to the compare file`
-          : `Simulation error: The output file differs from the compare file`,
+          ? {
+              message: `Simulation successful: The output file is identical to the compare file`,
+              severity: "SUCCESS",
+            }
+          : {
+              message: `Simulation error: The output file differs from the compare file`,
+              severity: "ERROR",
+            },
       );
     },
 
@@ -325,7 +337,10 @@ export function makeVmStore(
 
       if (isErr(tst)) {
         dispatch.current({ action: "setValid", payload: false });
-        setStatus(`Failed to parse test`);
+        setStatus({
+          message: `Failed to parse test`,
+          severity: "ERROR",
+        });
         return false;
       }
       dispatch.current({ action: "setValid", payload: true });
@@ -346,7 +361,10 @@ export function makeVmStore(
         },
       });
       if (isErr(maybeTest)) {
-        setStatus(Err(maybeTest).message);
+        setStatus({
+          message: Err(maybeTest).message,
+          severity: "ERROR",
+        });
         return false;
       } else {
         test = Ok(maybeTest).using(fs);
@@ -373,7 +391,10 @@ export function makeVmStore(
         }
         return done;
       } catch (e) {
-        setStatus(`Runtime error: ${(e as Error).message}`);
+        setStatus({
+          message: `Runtime error: ${(e as Error).message}`,
+          severity: "ERROR",
+        });
         dispatch.current({ action: "setValid", payload: false });
         return true;
       }
@@ -397,7 +418,10 @@ export function makeVmStore(
         }
         return done;
       } catch (e) {
-        setStatus(`Runtime error: ${(e as Error).message}`);
+        setStatus({
+          message: `Runtime error: ${(e as Error).message}`,
+          severity: "ERROR",
+        });
         dispatch.current({ action: "setValid", payload: false });
         return true;
       }

--- a/extension/views/hdl/src/index.tsx
+++ b/extension/views/hdl/src/index.tsx
@@ -8,6 +8,7 @@ import * as Not from "@nand2tetris/projects/project_01/01_not.js";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import { StatusSeverity } from "@nand2tetris/components/stores/base.context";
 
 const baseContext: BaseContext = {
   fs: new FileSystem(
@@ -17,10 +18,15 @@ const baseContext: BaseContext = {
   async upgradeFs() {},
   closeFs() {},
   storage: {},
-  status: "",
-  setStatus: (status: string): void => {
+  status: { message: "", severity: "INFO" },
+  setStatus: (status: string | { message: string; severity?: StatusSeverity }): void => {
     // api.postMessage({ nand2tetris: true, showMessage: status });
-    console.log(status);
+    if (typeof status === "string") {
+      console.log(status);
+    } else {
+      console.log(`${status.severity}: ${status.message}`);
+    }
+
   },
   permissionPrompt: {} as ReturnType<typeof useDialog>,
   // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/web/src/shell/statusline.scss
+++ b/web/src/shell/statusline.scss
@@ -1,0 +1,33 @@
+:root[data-theme="light"] {
+  --status-info-bg-color: inherit;
+  --status-success-bg-color: #aceebb;
+  --status-warning-bg-color: #f4e5b1;
+  --status-error-bg-color: #ffc1c0;
+}
+
+:root[data-theme="dark"] {
+  --status-info-bg-color: inherit;
+  --status-success-bg-color: #33792f;
+  --status-warning-bg-color: #7a6500;
+  --status-error-bg-color: #8e201a;
+}
+
+.StatusLine {
+  padding: 0.25rem 0.5rem;
+
+  &.status-info {
+    background-color: var(--status-info-bg-color);
+  }
+
+  &.status-success {
+    background-color: var(--status-success-bg-color);
+  }
+
+  &.status-warning {
+    background-color: var(--status-warning-bg-color);
+  }
+
+  &.status-error {
+    background-color: var(--status-error-bg-color);
+  }
+}

--- a/web/src/shell/statusline.tsx
+++ b/web/src/shell/statusline.tsx
@@ -1,9 +1,11 @@
 import { useContext } from "react";
 import { BaseContext } from "@nand2tetris/components/stores/base.context.js";
+import "./statusline.scss";
 
 function StatusLine() {
   const { status } = useContext(BaseContext);
-  return <div>{status}</div>;
+  const statusClass = `StatusLine status-${status.severity.toLowerCase()}`;
+  return <div className={statusClass}>{status.message}</div>;
 }
 
 export default StatusLine;

--- a/web/src/testing/index.tsx
+++ b/web/src/testing/index.tsx
@@ -43,7 +43,7 @@ export const useTestingAppContext = () => ({
     async upgradeFs() {},
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     closeFs(force?: boolean) {},
-    status: "",
+    status: { message: "", severity: "INFO" },
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     setStatus() {},
     storage: {},


### PR DESCRIPTION
Adding this feature: https://github.com/nand2tetris/web-ide/issues/428

- Introduces 4 levels of status messages: SUCCESS, WARNING, ERROR, and INFO
- The background color for status line is changed to: green, yellow, red respectively and is not changed for INFO messages
- The default level for `setStatus` is considered INFO, backward compatibility is kept
- Both color schemes are supported

![Screenshot 2025-06-09 at 14 35 33](https://github.com/user-attachments/assets/ceec1a09-70f3-4e14-92c1-469e78ae8a28)
![Screenshot 2025-06-09 at 14 35 49](https://github.com/user-attachments/assets/736294c8-7d74-47e0-9214-354d0784a8d3)
