### PR TITLE
Allow users to upload local .tst and .cmp files in CPU Emulator

### DIFF
--- a/web/src/shell/test_panel.tsx
+++ b/web/src/shell/test_panel.tsx
@@ -30,7 +30,6 @@ import { isPath } from "./file_select";
 import { Panel } from "./panel";
 import { Tab, TabList } from "./tabs";
 
-
 const WARNING_KEY = "skipTestEditWarning";
 
 export const TestPanel = ({

--- a/web/src/shell/test_panel.tsx
+++ b/web/src/shell/test_panel.tsx
@@ -26,9 +26,10 @@ import {
 } from "react";
 import { AppContext } from "../App.context";
 import { Editor } from "./editor";
+import { isPath } from "./file_select";
 import { Panel } from "./panel";
 import { Tab, TabList } from "./tabs";
-import { isPath } from "src/shell/file_select";
+
 
 const WARNING_KEY = "skipTestEditWarning";
 


### PR DESCRIPTION
As described in issues #543 #565 #551 and #543, using the built-in Mult.tst file always overwrite users' programs in RAM, which makes CPU Emulator completely unusable in project 4. Therefore, I changed loadTest such that:

- It allows users to upload local .cmp and .tst file

Benefits:

- Users can use their .tst file without the problematic `load Mult.asm`
- The current fs-based test loading is maintained

However, it requires users to load .cmp and .tst separately, and `compare-to Mult.cmp` must be removed simultaneously to use local .cmp file.

<img width="434" height="510" alt="2025-08-13_13-23" src="https://github.com/user-attachments/assets/ebd7d3b9-17b7-4748-be1b-a424c18b772f" />

<img width="351" height="682" alt="2025-08-13_13-23_1" src="https://github.com/user-attachments/assets/541a677e-e729-477a-bd20-d81ed76744cd" />
